### PR TITLE
Minor update

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -4,7 +4,9 @@ namespace Omnipay\Worldline;
 
 use Omnipay\Common\AbstractGateway;
 use Omnipay\Worldline\Message\CompletePurchaseRequest;
+use Omnipay\Worldline\Message\FetchTransactionRequest;
 use Omnipay\Worldline\Message\PurchaseRequest;
+use Omnipay\Worldline\Message\RefundRequest;
 
 /**
  * Worldline Hosted Checkout Gateway
@@ -68,5 +70,15 @@ class Gateway extends AbstractGateway
     public function completePurchase(array $parameters = [])
     {
         return $this->createRequest(CompletePurchaseRequest::class, $parameters);
+    }
+
+    public function refund(array $parameters = [])
+    {
+        return $this->createRequest(RefundRequest::class, $parameters);
+    }
+
+    public function fetchTransaction(array $parameters = [])
+    {
+        return $this->createRequest(FetchTransactionRequest::class, $parameters);
     }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+use DateTime;
+use DateTimeZone;
+use Money\Currency;
+use Money\Number;
+use Money\Parser\DecimalMoneyParser;
+use Omnipay\Common\Message\AbstractRequest as BaseAbstractRequest;
+use Omnipay\Common\Exception\InvalidRequestException;
+
+/**
+ * Base request for Worldline
+ *
+ * @see https://docs.direct.worldline-solutions.com/en/integration/api-developer-guide/authentication
+ */
+abstract class AbstractRequest extends BaseAbstractRequest
+{
+    /** @var string */
+    protected $liveEndpoint = 'https://payment.direct.worldline-solutions.com';
+    /** @var string */
+    protected $testEndpoint = 'https://payment.preprod.direct.worldline-solutions.com';
+    /** @var string HTTP verb used to make the request */
+    protected $requestMethod = 'GET';
+
+    public function getApiKey()
+    {
+        return $this->getParameter('apiKey');
+    }
+
+    public function setApiKey($value)
+    {
+        return $this->setParameter('apiKey', $value);
+    }
+
+    public function getApiSecret()
+    {
+        return $this->getParameter('apiSecret');
+    }
+
+    public function setApiSecret($value)
+    {
+        return $this->setParameter('apiSecret', $value);
+    }
+
+    public function getMerchantId()
+    {
+        return $this->getParameter('merchantId');
+    }
+
+    public function setMerchantId($value)
+    {
+        return $this->setParameter('merchantId', $value);
+    }
+
+    public function getEndpoint()
+    {
+        return ($this->getTestMode() ? $this->testEndpoint : $this->liveEndpoint).$this->getAction();
+    }
+
+    public function sendData($data)
+    {
+        $contentType = $this->requestMethod == 'POST' ? 'application/json; charset=utf-8' : '';
+        $now = new DateTime('now', new DateTimeZone('GMT'));
+        $dateTime = $now->format("D, d M Y H:i:s T");
+        $endpointAction = $this->getAction();
+
+        $message = $this->requestMethod."\n".$contentType."\n".$dateTime."\n".$endpointAction."\n";
+        $signature = $this->createSignature($message, $this->getApiSecret());
+
+        $headers = [
+            'Content-Type' => $contentType,
+            'Authorization' => 'GCS v1HMAC:'.$this->getApiKey().':'.$signature,
+            'Date' => $dateTime,
+        ];
+
+        $body = json_encode($data);
+
+        $httpResponse = $this->httpClient->request(
+            $this->requestMethod,
+            $this->getEndpoint(),
+            $headers,
+            $body
+        );
+
+        return $this->createResponse($httpResponse->getBody()->getContents());
+    }
+
+    /**
+     * @param mixed $data
+     * @return AbstractResponse
+     */
+    abstract protected function createResponse($data);
+
+    /**
+     * @return string
+     */
+    abstract protected function getAction();
+
+    /**
+     * Create signature hash used to verify messages
+     *
+     * @param string $message  The message to encrypt
+     * @param string $key      The base64-encoded key used to encrypt the message
+     *
+     * @return string Generated signature
+     */
+    protected function createSignature($message, $key)
+    {
+        return base64_encode(hash_hmac('sha256', $message, $key, true));
+    }
+
+    /**
+     * Get integer version (sallest unit) of item price
+     *
+     * Copied from {@see BaseAbstractRequest::getAmountInteger()} & {@see BaseAbstractRequest::getMoney()}
+     */
+    protected function getItemPriceInteger($item)
+    {
+        $currencyCode = $this->getCurrency() ?: 'USD';
+        $currency = new Currency($currencyCode);
+        $amount = $item->getPrice();
+
+        $moneyParser = new DecimalMoneyParser($this->getCurrencies());
+        $number = Number::fromString($amount);
+        // Check for rounding that may occur if too many significant decimal digits are supplied.
+        $decimal_count = strlen($number->getFractionalPart());
+        $subunit = $this->getCurrencies()->subunitFor($currency);
+        if ($decimal_count > $subunit) {
+            throw new InvalidRequestException('Amount precision is too high for currency.');
+        }
+        $money = $moneyParser->parse((string) $number, $currency);
+
+        return (int) $money->getAmount();
+    }
+}

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -7,10 +7,8 @@ namespace Omnipay\Worldline\Message;
  *
  * @see https://docs.direct.worldline-solutions.com/en/api-reference#tag/HostedCheckout/operation/GetHostedCheckoutApi
  */
-class CompletePurchaseRequest extends PurchaseRequest
+class CompletePurchaseRequest extends AbstractRequest
 {
-    protected $requestMethod = 'GET';
-
     public function getHostedCheckoutId()
     {
         return $this->getParameter('hostedCheckoutId');
@@ -23,6 +21,8 @@ class CompletePurchaseRequest extends PurchaseRequest
 
     public function getData()
     {
+        $this->validate('merchantId', 'hostedCheckoutId');
+
         return $this->httpRequest->request->all();
     }
 

--- a/src/Message/FetchTransactionRequest.php
+++ b/src/Message/FetchTransactionRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+/**
+ * Worldline Fetch Transaction Request
+ *
+ * @see https://docs.direct.worldline-solutions.com/en/api-reference#tag/Payments/operation/GetPaymentDetailsApi
+ */
+class FetchTransactionRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('merchantId', 'transactionReference');
+        return [];
+    }
+
+    protected function createResponse($data)
+    {
+        return $this->response = new FetchTransactionResponse($this, json_decode($data));
+    }
+
+    protected function getAction()
+    {
+        return '/v2/'.$this->getMerchantId().'/payments/'.$this->getTransactionReference().'/details';
+    }
+}

--- a/src/Message/FetchTransactionResponse.php
+++ b/src/Message/FetchTransactionResponse.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+
+/**
+ * Worldline Fetch Transaction Response
+ */
+class FetchTransactionResponse extends AbstractResponse
+{
+    /**
+     * Is the response pending success or failure?
+     *
+     * @return boolean
+     */
+    public function isPending()
+    {
+        if (empty($this->data) || isset($this->data->errorId)) {
+            return false;
+        }
+
+        return $this->data->statusOutput->statusCategory == 'PENDING_CONNECT_OR_3RD_PARTY';
+    }
+
+    /**
+     * Is the response successful?
+     *
+     * @return boolean
+     */
+    public function isSuccessful()
+    {
+        if (empty($this->data) || isset($this->data->errorId)) {
+            return false;
+        }
+
+        return in_array($this->data->statusOutput->statusCategory, ['COMPLETED', 'REFUNDED']);
+    }
+
+    /**
+     * Numeric status code (also in back office / report files)
+     *
+     * @return null|string
+     */
+    public function getCode()
+    {
+        return $this->data->statusOutput->statusCode ?? $this->data->errors[0]->errorCode ?? null;
+    }
+
+    /**
+     * Get the authorisation code if available.
+     *
+     * @return null|string
+     */
+    public function getTransactionReference()
+    {
+        return $this->data->id ?? null;
+    }
+
+    /**
+     * Get the merchant response message if available.
+     *
+     * @return null|string
+     */
+    public function getMessage()
+    {
+        return $this->data->status ?? $this->data->errorId ?? null;
+    }
+}

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+/**
+ * Worldline Refund Request
+ *
+ * @see https://docs.direct.worldline-solutions.com/en/api-reference#tag/Payments/operation/RefundPaymentApi
+ */
+class RefundRequest extends AbstractRequest
+{
+    protected $requestMethod = 'POST';
+
+    public function getData()
+    {
+        $this->validate('merchantId', 'amount', 'currency', 'transactionReference');
+
+        $data = [
+            'amountOfMoney' => [
+                'amount' => $this->getAmountInteger(),
+                'currencyCode' => $this->getCurrency(),
+            ],
+            'operationReferences' => [
+                'merchantReference' => $this->getTransactionId(),
+            ],
+        ];
+
+        return $data;
+    }
+
+    protected function createResponse($data)
+    {
+        return $this->response = new RefundResponse($this, json_decode($data));
+    }
+
+    protected function getAction()
+    {
+        return '/v2/'.$this->getMerchantId().'/payments/'.$this->getTransactionReference().'/refund';
+    }
+}

--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+
+/**
+ * Worldline Refund Response
+ */
+class RefundResponse extends AbstractResponse
+{
+    /**
+     * Is the response pending success or failure?
+     *
+     * @return boolean
+     */
+    public function isPending()
+    {
+        if (empty($this->data) || isset($this->data->errorId)) {
+            return false;
+        }
+
+        return $this->data->status == 'REFUND_REQUESTED';
+    }
+
+    /**
+     * Is the response successful?
+     *
+     * @return boolean
+     */
+    public function isSuccessful()
+    {
+        if (empty($this->data) || isset($this->data->errorId)) {
+            return false;
+        }
+
+        return $this->data->status == 'REFUNDED';
+    }
+
+    /**
+     * Numeric status code (also in back office / report files)
+     *
+     * @return null|string
+     */
+    public function getCode()
+    {
+        return $this->data->statusOutput->statusCode
+            ?? $this->data->refundResult->statusOutput->statusCode
+            ?? $this->data->errors[0]->errorCode
+            ?? null;
+    }
+
+    /**
+     * Get the authorisation code if available.
+     *
+     * @return null|string
+     */
+    public function getTransactionReference()
+    {
+        return $this->data->id ?? null;
+    }
+
+    /**
+     * Get the merchant response message if available.
+     *
+     * @return null|string
+     */
+    public function getMessage()
+    {
+        return $this->data->status ?? $this->data->errorId ?? null;
+    }
+}

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -65,11 +65,75 @@ class GatewayTest extends GatewayTestCase
 
         $options = array_merge($this->options, ['hostedCheckoutId' => '0000000001']);
 
-        $response = $this->gateway->completePurchase($this->options)->send();
+        $response = $this->gateway->completePurchase($options)->send();
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('1234567890_0', $response->getTransactionReference());
         $this->assertSame('CANCELLED', $response->getMessage());
+    }
+
+    public function testRefundSuccess()
+    {
+        $this->setMockHttpResponse('RefundSuccess.txt');
+
+        $options = $this->options + ['transactionReference' => '0000000001_0'];
+
+        $response = $this->gateway->refund($options)->send();
+
+        $this->assertFalse($response->isPending());
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('REFUNDED', $response->getMessage());
+        $this->assertSame(8, $response->getCode());
+        $this->assertSame('0000000001_1', $response->getTransactionReference());
+    }
+
+    public function testRefundPending()
+    {
+        $this->setMockHttpResponse('RefundPending.txt');
+
+        $options = $this->options + ['transactionReference' => '0000000001_0'];
+
+        $response = $this->gateway->refund($options)->send();
+
+        $this->assertTrue($response->isPending());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('REFUND_REQUESTED', $response->getMessage());
+        $this->assertSame(81, $response->getCode());
+        $this->assertSame('0000000001_1', $response->getTransactionReference());
+    }
+
+    public function testRefundFailure()
+    {
+        $this->setMockHttpResponse('RefundFailure.txt');
+
+        $options = $this->options + ['transactionReference' => '0000000001_0'];
+
+        $response = $this->gateway->refund($options)->send();
+
+        $this->assertFalse($response->isPending());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('11111111-2222-3333-4444-abcdefabcdef', $response->getMessage());
+        $this->assertSame('50001130', $response->getCode());
+        $this->assertNull($response->getTransactionReference());
+    }
+
+    public function testFetchTransactionSuccess()
+    {
+        $this->setMockHttpResponse('FetchTransactionSuccess.txt');
+
+        $options = $this->options + ['transactionReference' => '0000000001_0'];
+
+        $response = $this->gateway->fetchTransaction($options)->send();
+
+        $this->assertFalse($response->isPending());
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('CAPTURED', $response->getMessage());
+        $this->assertSame(9, $response->getCode());
+        $this->assertSame('0000000001_0', $response->getTransactionReference());
     }
 }

--- a/tests/Message/FetchTransactionResponseTest.php
+++ b/tests/Message/FetchTransactionResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+use Omnipay\Tests\TestCase;
+
+class FetchTransactionResponseTest extends TestCase
+{
+    public function testRefundError()
+    {
+        $response = new FetchTransactionResponse($this->getMockRequest(), (object) [
+            'errorId' => '12345678-abcd-ef90-1234-567890abcdef-00000092',
+            'errors' => [
+                (object) [
+                    'errorCode' => 50001130,
+                    'category' => 'PAYMENT_PLATFORM_ERROR',
+                    'code' => 1002,
+                    'httpStatusCode' => 404,
+                    'id' => 'UNKNOWN_PAYMENT_ID',
+                    'message' => 'PaymentId has a wrong syntax',
+                    'retriable' => false,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($response->isPending());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame(50001130, $response->getCode());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('12345678-abcd-ef90-1234-567890abcdef-00000092', $response->getMessage());
+    }
+}

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -103,6 +103,11 @@ class PurchaseRequestTest extends TestCase
     {
         $data = $this->request->getData();
 
+        $this->assertArrayHasKey("cardPaymentMethodSpecificInput", $data);
+        $this->assertArrayHasKey("authorizationMode", $data["cardPaymentMethodSpecificInput"]);
+        $this->assertSame("SALE", $data["cardPaymentMethodSpecificInput"]['authorizationMode']);
+        $this->assertArrayHasKey("transactionChannel", $data["cardPaymentMethodSpecificInput"]);
+        $this->assertSame("ECOMMERCE", $data["cardPaymentMethodSpecificInput"]['transactionChannel']);
         $this->assertArrayHasKey("hostedCheckoutSpecificInput", $data);
         $this->assertArrayHasKey("returnUrl", $data["hostedCheckoutSpecificInput"]);
         $this->assertSame("https://www.example.com/return", $data['hostedCheckoutSpecificInput']['returnUrl']);
@@ -150,5 +155,33 @@ class PurchaseRequestTest extends TestCase
 
         $this->expectException(InvalidRequestException::class);
         $data = $request->getData();
+    }
+
+    public function testMotoTransactionChannel()
+    {
+        $params = $this->allParams;
+        $params['transactionChannel'] = 'MOTO';
+        $request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $request->initialize($params);
+
+        $data = $request->getData();
+
+        $this->assertArrayHasKey("cardPaymentMethodSpecificInput", $data);
+        $this->assertArrayHasKey("transactionChannel", $data["cardPaymentMethodSpecificInput"]);
+        $this->assertSame("MOTO", $data["cardPaymentMethodSpecificInput"]['transactionChannel']);
+    }
+
+    public function testInvalidTransactionChannel()
+    {
+        $params = $this->allParams;
+        $params['transactionChannel'] = 'INVALID';
+        $request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $request->initialize($params);
+
+        $data = $request->getData();
+
+        $this->assertArrayHasKey("cardPaymentMethodSpecificInput", $data);
+        $this->assertArrayHasKey("transactionChannel", $data["cardPaymentMethodSpecificInput"]);
+        $this->assertSame("ECOMMERCE", $data["cardPaymentMethodSpecificInput"]['transactionChannel']);
     }
 }

--- a/tests/Message/RefundResponseTest.php
+++ b/tests/Message/RefundResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Omnipay\Worldline\Message;
+
+use Omnipay\Tests\TestCase;
+
+class RefundResponseTest extends TestCase
+{
+    public function testRefundError()
+    {
+        $response = new RefundResponse($this->getMockRequest(), (object) [
+            'errorId' => '12345678-abcd-ef90-1234-567890abcdef',
+            'errors' => [
+                (object) [
+                    'errorCode' => 50001129,
+                    'category' => 'PAYMENT_PLATFORM_ERROR',
+                    'code' => 1020,
+                    'httpStatusCode' => 400,
+                    'id' => 'ACTION_NOT_ALLOWED_ON_TRANSACTION',
+                    'message' => 'ACTION_NOT_ALLOWED_ON_TRANSACTION',
+                    'retriable' => false,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($response->isPending());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame(50001129, $response->getCode());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('12345678-abcd-ef90-1234-567890abcdef', $response->getMessage());
+    }
+}

--- a/tests/Mock/FetchTransactionSuccess.txt
+++ b/tests/Mock/FetchTransactionSuccess.txt
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+Date: Thu, 01 May 2025 01:43:28 GMT
+Content-Length: 1234
+Content-Type: application/json; charset=utf-8
+Correlation-Id: 11111111-2222-3333-4444-abcdefabcdef
+Api_Auth: true
+Strict-Transport-Security: max-age=16000000; includeSubDomains; preload;
+
+{"paymentOutput":{"amountOfMoney":{"amount":145,"currencyCode":"EUR"},"references":{"merchantReference":"123abc"},"acquiredAmount":{"amount":145,"currencyCode":"EUR"},"customer":{"device":{"ipAddressCountryCode":"99"}},"cardPaymentMethodSpecificOutput":{"paymentProductId":1,"authorisationCode":"123456789","card":{"cardNumber":"************4675","expiryDate":"1234","bin":"43302649","countryCode":"BE","cardType":"Credit","panLengthMax":19,"panLengthMin":13},"fraudResults":{"fraudServiceResult":"no-advice","avsResult":"U","cvvResult":"0"},"schemeReferenceData":"123456789012","paymentAccountReference":"ABCDEFGHIJKLMNOPQRSTUVWZYZ123","threeDSecureResults":{"eci":"1","xid":"ABCDEFGHIJKLMN=="},"acquirerInformation":{"name":"ACQUIRER"},"cobrandSelectionIndicator":"alternative"},"paymentMethod":"card"},"Operations":[{"id":"0000000001_0","amountOfMoney":{"amount":145,"currencyCode":"EUR"},"status":"CAPTURED","statusOutput":{"isCancellable":false,"statusCategory":"COMPLETED","statusCode":9,"isAuthorized":false,"isRefundable":true},"paymentMethod":"card","references":{"merchantReference":"123abc"},"operationReferences":{"merchantReference":"123abc"},"paymentProductId":1}],"status":"CAPTURED","statusOutput":{"isCancellable":false,"statusCategory":"COMPLETED","statusCode":9,"isAuthorized":false,"isRefundable":true},"id":"0000000001_0"}

--- a/tests/Mock/RefundFailure.txt
+++ b/tests/Mock/RefundFailure.txt
@@ -1,0 +1,9 @@
+HTTP/1.1 400 Bad Request
+Date: Thu, 01 May 2025 01:43:28 GMT
+Content-Length: 241
+Content-Type: application/json; charset=utf-8
+Correlation-Id: 11111111-2222-3333-4444-abcdefabcdef
+Api_Auth: true
+Strict-Transport-Security: max-age=16000000; includeSubDomains; preload;
+
+{"errorId":"11111111-2222-3333-4444-abcdefabcdef","errors":[{"errorCode":"50001130","category":"DIRECT_PLATFORM_ERROR","code":"1002","httpStatusCode":404,"id":"UNKNOWN_PAYMENT_ID","message":"PaymentId has a wrong syntax","retriable":false}]}

--- a/tests/Mock/RefundPending.txt
+++ b/tests/Mock/RefundPending.txt
@@ -1,0 +1,9 @@
+HTTP/1.1 201 Created
+Date: Thu, 01 May 2025 01:43:28 GMT
+Content-Length: 241
+Content-Type: application/json; charset=utf-8
+Correlation-Id: 11111111-2222-3333-4444-abcdefabcdef
+Api_Auth: true
+Strict-Transport-Security: max-age=16000000; includeSubDomains; preload;
+
+{"refundOutput":{"amountOfMoney":{"amount":145,"currencyCode":"EUR"},"references":{"merchantReference":"123abc"},"operationReferences":{"merchantReference":"123abc"},"cardRefundMethodSpecificOutput":{"totalAmountPaid":145,"totalAmountRefunded":0},"paymentMethod":"card"},"status":"REFUND_REQUESTED","statusOutput":{"isCancellable":false,"statusCategory":"PENDING_CONNECT_OR_3RD_PARTY","statusCode":81},"id":"0000000001_1"}

--- a/tests/Mock/RefundSuccess.txt
+++ b/tests/Mock/RefundSuccess.txt
@@ -1,0 +1,9 @@
+HTTP/1.1 201 Created
+Date: Thu, 01 May 2025 01:43:28 GMT
+Content-Length: 241
+Content-Type: application/json; charset=utf-8
+Correlation-Id: 11111111-2222-3333-4444-abcdefabcdef
+Api_Auth: true
+Strict-Transport-Security: max-age=16000000; includeSubDomains; preload;
+
+{"status":"REFUNDED","statusOutput":{"isCancellable":false,"statusCategory":"REFUNDED","statusCode":8,"statusCodeChangeDateTime":""},"id":"0000000001_1"}


### PR DESCRIPTION
* add `refund()` support, including pending state
* add `fetchTransaction()` support
* add support for MOTO transactions
* update complete purchase requests to validate necessary URL parameters
* update requests to use a common local `AbstractRequest`